### PR TITLE
Add minimal blog with Firebase Auth and Firestore

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,109 +1,109 @@
 "use client";
-import Image from "next/image";
-import { useEffect } from "react";
-import { firebaseApp } from "@/firebase";
+import { useEffect, useState } from "react";
+import {
+  firestore,
+  auth
+} from "@/firebase";
+import {
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  Timestamp,
+  DocumentData
+} from "firebase/firestore";
+import {
+  GoogleAuthProvider,
+  signInWithPopup,
+  onAuthStateChanged,
+  signOut,
+  User
+} from "firebase/auth";
 
 export default function Home() {
-  useEffect(() => {
-    console.log("Firebase app initialized:", firebaseApp.name);
-  }, []);
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const [user, setUser] = useState<User | null>(null);
+  const [posts, setPosts] = useState<DocumentData[]>([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
+  useEffect(() => {
+    const unsubAuth = onAuthStateChanged(auth, (u) => setUser(u));
+    const postsQuery = query(
+      collection(firestore, "posts"),
+      orderBy("created", "desc")
+    );
+    const unsubPosts = onSnapshot(postsQuery, (snap) => {
+      setPosts(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return () => {
+      unsubAuth();
+      unsubPosts();
+    };
+  }, []);
+
+  const signIn = async () => {
+    await signInWithPopup(auth, new GoogleAuthProvider());
+  };
+
+  const signOutUser = () => signOut(auth);
+
+  const addPost = async () => {
+    if (!title || !content) return;
+    await addDoc(collection(firestore, "posts"), {
+      title,
+      content,
+      created: Timestamp.now(),
+      uid: user?.uid,
+    });
+    setTitle("");
+    setContent("");
+  };
+
+  return (
+    <main className="max-w-xl mx-auto p-4 space-y-4">
+      <header className="flex justify-between items-center">
+        <h1 className="text-xl font-bold">Minimal Blog</h1>
+        {user ? (
+          <button onClick={signOutUser} className="underline">
+            Sign out
+          </button>
+        ) : (
+          <button onClick={signIn} className="underline">
+            Sign in with Google
+          </button>
+        )}
+      </header>
+
+      {user && (
+        <div className="space-y-2">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="Title"
+            className="w-full p-2 border"
+          />
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Content"
+            className="w-full p-2 border"
+          />
+          <button onClick={addPost} className="bg-black text-white px-4 py-2">
+            Add Post
+          </button>
         </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+      )}
+
+      <ul className="space-y-4">
+        {posts.map((post) => (
+          <li key={post.id} className="border p-2">
+            <h2 className="font-semibold">{post.title}</h2>
+            <p>{post.content}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
   );
 }

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,6 +1,8 @@
 // Firebase initialization
 import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
+import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBsd8CmzMA4U_p3B5Bimpyne4gRHmHlGR8",
@@ -14,5 +16,8 @@ const firebaseConfig = {
 
 // Initialize Firebase
 export const firebaseApp = initializeApp(firebaseConfig);
-export const firebaseAnalytics = typeof window !== "undefined" ? getAnalytics(firebaseApp) : undefined;
+export const firebaseAnalytics =
+  typeof window !== "undefined" ? getAnalytics(firebaseApp) : undefined;
+export const firestore = getFirestore(firebaseApp);
+export const auth = getAuth(firebaseApp);
 


### PR DESCRIPTION
## Summary
- set up Firestore and Firebase Auth exports
- replace the example home page with a minimal blog using Firestore for posts and Firebase Auth for sign-in

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: cannot fetch fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68897abb07c08328a976a3c85ab219ce