### PR TITLE
Add login & register pages

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useState } from "react";
+import { signInWithEmailAndPassword } from "firebase/auth";
+import { auth } from "@/firebase";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const signIn = async () => {
+    if (!email || !password) return;
+    await signInWithEmailAndPassword(auth, email, password);
+    router.push("/");
+  };
+
+  return (
+    <main className="max-w-sm mx-auto p-4 space-y-4">
+      <h1 className="text-xl font-bold text-center">Login</h1>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="w-full p-2 border"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="w-full p-2 border"
+      />
+      <button
+        onClick={signIn}
+        className="bg-black text-white w-full py-2"
+      >
+        Login
+      </button>
+      <p className="text-center">
+        New here? <Link href="/register" className="underline">Register</Link>
+      </p>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
-import {
-  firestore,
-  auth
-} from "@/firebase";
+import Link from "next/link";
+import { firestore, auth } from "@/firebase";
 import {
   collection,
   addDoc,
@@ -11,26 +9,18 @@ import {
   query,
   orderBy,
   Timestamp,
-  DocumentData
+  DocumentData,
 } from "firebase/firestore";
-import {
-  createUserWithEmailAndPassword,
-  signInWithEmailAndPassword,
-  onAuthStateChanged,
-  signOut,
-  User,
-} from "firebase/auth";
+import { onAuthStateChanged, signOut, User } from "firebase/auth";
 
 export default function Home() {
   const [user, setUser] = useState<User | null>(null);
   const [posts, setPosts] = useState<DocumentData[]>([]);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
 
   useEffect(() => {
-    const unsubAuth = onAuthStateChanged(auth, (u) => setUser(u));
+    const unsubAuth = onAuthStateChanged(auth, setUser);
     const postsQuery = query(
       collection(firestore, "posts"),
       orderBy("created", "desc")
@@ -44,66 +34,39 @@ export default function Home() {
     };
   }, []);
 
-  const signIn = async () => {
-    if (!email || !password) return;
-    await signInWithEmailAndPassword(auth, email, password);
-  };
-
-  const register = async () => {
-    if (!email || !password) return;
-    await createUserWithEmailAndPassword(auth, email, password);
-  };
-
-  const signOutUser = () => signOut(auth);
-
   const addPost = async () => {
-    if (!title || !content) return;
+    if (!title || !content || !user) return;
     await addDoc(collection(firestore, "posts"), {
       title,
       content,
       created: Timestamp.now(),
-      uid: user?.uid,
+      uid: user.uid,
     });
     setTitle("");
     setContent("");
   };
 
+  const signOutUser = () => signOut(auth);
+
   return (
     <main className="max-w-xl mx-auto p-4 space-y-4">
       <header className="flex justify-between items-center">
         <h1 className="text-xl font-bold">Minimal Blog</h1>
-        {user && (
+        {user ? (
           <button onClick={signOutUser} className="underline">
             Sign out
           </button>
+        ) : (
+          <Link href="/login" className="underline">
+            Login
+          </Link>
         )}
       </header>
 
       {!user && (
-        <div className="space-y-2">
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="Email"
-            className="w-full p-2 border"
-          />
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Password"
-            className="w-full p-2 border"
-          />
-          <div className="flex space-x-4">
-            <button onClick={signIn} className="underline">
-              Login
-            </button>
-            <button onClick={register} className="underline">
-              Register
-            </button>
-          </div>
-        </div>
+        <p>
+          New here? <Link href="/register" className="underline">Register</Link>
+        </p>
       )}
 
       {user && (
@@ -130,7 +93,7 @@ export default function Home() {
       <ul className="space-y-4">
         {posts.map((post) => (
           <li key={post.id} className="border p-2">
-            <h2 className="font-semibold">{post.title}</h2>
+            <h2 className="font-semibold text-lg">{post.title}</h2>
             <p>{post.content}</p>
           </li>
         ))}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { useState } from "react";
+import { createUserWithEmailAndPassword } from "firebase/auth";
+import { auth } from "@/firebase";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const register = async () => {
+    if (!email || !password) return;
+    await createUserWithEmailAndPassword(auth, email, password);
+    router.push("/");
+  };
+
+  return (
+    <main className="max-w-sm mx-auto p-4 space-y-4">
+      <h1 className="text-xl font-bold text-center">Register</h1>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="w-full p-2 border"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="w-full p-2 border"
+      />
+      <button
+        onClick={register}
+        className="bg-black text-white w-full py-2"
+      >
+        Register
+      </button>
+      <p className="text-center">
+        Already have an account? <Link href="/login" className="underline">Login</Link>
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- split login and register features into separate pages
- simplify home page to link to the new auth pages

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6889825a468883288a1cd4afdefbea3a