### PR TITLE
Fix Firestore post submission

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import {
   query,
   orderBy,
   Timestamp,
+  serverTimestamp,
   DocumentData,
 } from "firebase/firestore";
 import { onAuthStateChanged, signOut, User } from "firebase/auth";
@@ -36,14 +37,19 @@ export default function Home() {
 
   const addPost = async () => {
     if (!title || !content || !user) return;
-    await addDoc(collection(firestore, "posts"), {
-      title,
-      content,
-      created: Timestamp.now(),
-      uid: user.uid,
-    });
-    setTitle("");
-    setContent("");
+    try {
+      await addDoc(collection(firestore, "posts"), {
+        title,
+        content,
+        // Use Firestore server time to avoid client clock issues
+        created: serverTimestamp(),
+        uid: user.uid,
+      });
+      setTitle("");
+      setContent("");
+    } catch (err) {
+      console.error("Failed to add post", err);
+    }
   };
 
   const signOutUser = () => signOut(auth);

--- a/firebase.ts
+++ b/firebase.ts
@@ -8,7 +8,8 @@ const firebaseConfig = {
   apiKey: "AIzaSyBsd8CmzMA4U_p3B5Bimpyne4gRHmHlGR8",
   authDomain: "yuki-906f3.firebaseapp.com",
   projectId: "yuki-906f3",
-  storageBucket: "yuki-906f3.firebasestorage.app",
+  // Correct the storage bucket domain
+  storageBucket: "yuki-906f3.appspot.com",
   messagingSenderId: "91239365480",
   appId: "1:91239365480:web:2ad7d59ebe48941a9874dd",
   measurementId: "G-PJ6JKLKMQC",


### PR DESCRIPTION
## Summary
- correct Firebase storage bucket domain
- handle errors when adding posts
- use Firestore `serverTimestamp` when saving posts

## Testing
- `npm run lint` *(fails: asks how to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68898711528883289035cb4a089924a8