### PR TITLE
Add admin page and image uploads

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { auth } from "@/firebase";
+import {
+  onAuthStateChanged,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  User,
+} from "firebase/auth";
+
+export default function AdminPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, setUser);
+  }, []);
+
+  const submit = async () => {
+    if (!email || !password) return;
+    if (mode === "login") {
+      await signInWithEmailAndPassword(auth, email, password);
+    } else {
+      await createUserWithEmailAndPassword(auth, email, password);
+    }
+    setEmail("");
+    setPassword("");
+  };
+
+  const logout = () => signOut(auth);
+
+  if (user) {
+    return (
+      <main className="max-w-sm mx-auto p-4 bg-white text-black space-y-4 min-h-screen flex flex-col justify-center">
+        <h1 className="text-xl font-bold text-center">Admin Panel</h1>
+        <p className="text-center">Logged in as {user.email}</p>
+        <button onClick={logout} className="bg-black text-white py-2">Sign out</button>
+        <Link href="/" className="underline text-center">Back to Home</Link>
+      </main>
+    );
+  }
+
+  return (
+    <main className="max-w-sm mx-auto p-4 bg-white text-black space-y-4 min-h-screen flex flex-col justify-center">
+      <h1 className="text-xl font-bold text-center">Admin Login</h1>
+      <input
+        type="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+        className="w-full p-2 border"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+        className="w-full p-2 border"
+      />
+      <button onClick={submit} className="bg-black text-white w-full py-2">
+        {mode === "login" ? "Login" : "Register"}
+      </button>
+      <p className="text-center">
+        {mode === "login" ? (
+          <>New here? <button onClick={() => setMode("register") } className="underline">Register</button></>
+        ) : (
+          <>Have an account? <button onClick={() => setMode("login") } className="underline">Login</button></>
+        )}
+      </p>
+    </main>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
   };
 
   return (
-    <main className="max-w-sm mx-auto p-4 space-y-4">
+    <main className="max-w-sm mx-auto p-4 space-y-4 bg-white text-black min-h-screen flex flex-col justify-center">
       <h1 className="text-xl font-bold text-center">Login</h1>
       <input
         type="email"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState, FormEvent } from "react";
 import Link from "next/link";
-import { firestore, auth } from "@/firebase";
+import { firestore, auth, storage } from "@/firebase";
 import {
   collection,
   addDoc,
@@ -14,6 +14,7 @@ import {
   Timestamp,
   QueryDocumentSnapshot,
 } from "firebase/firestore";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { onAuthStateChanged, signOut, User } from "firebase/auth";
 
 // --- Types ---
@@ -22,6 +23,7 @@ type ServerTimestamp = ReturnType<typeof serverTimestamp>;
 type PostDoc = {
   title: string;
   content: string;
+  imageUrl?: string | null;
   created: Timestamp | ServerTimestamp; // write: serverTimestamp(), read: Timestamp
   uid: string;
 };
@@ -47,6 +49,7 @@ export default function Home() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [image, setImage] = useState<File | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -79,32 +82,41 @@ export default function Home() {
   }, [user, title, content, submitting]);
 
   const addPost = useCallback(
-      async (e?: FormEvent) => {
-        e?.preventDefault();
-        if (!canSubmit) return;
+    async (e?: FormEvent) => {
+      e?.preventDefault();
+      if (!canSubmit) return;
 
-        setSubmitting(true);
-        setError(null);
+      setSubmitting(true);
+      setError(null);
 
-        try {
-          const postsCol = collection(firestore, POSTS_COLLECTION).withConverter(postConverter);
-          const payload: PostDoc = {
-            title: title.trim(),
-            content: content.trim(),
-            created: serverTimestamp(),
-            uid: user!.uid,
-          };
-          await addDoc(postsCol, payload);
-          setTitle("");
-          setContent("");
-        } catch (err) {
-          console.error(err);
-          setError("Failed to add post.");
-        } finally {
-          setSubmitting(false);
+      try {
+        let imageUrl: string | null = null;
+        if (image) {
+          const imageRef = ref(storage, `posts/${Date.now()}-${image.name}`);
+          await uploadBytes(imageRef, image);
+          imageUrl = await getDownloadURL(imageRef);
         }
-      },
-      [canSubmit, title, content, user]
+
+        const postsCol = collection(firestore, POSTS_COLLECTION).withConverter(postConverter);
+        const payload: PostDoc = {
+          title: title.trim(),
+          content: content.trim(),
+          imageUrl,
+          created: serverTimestamp(),
+          uid: user!.uid,
+        };
+        await addDoc(postsCol, payload);
+        setTitle("");
+        setContent("");
+        setImage(null);
+      } catch (err) {
+        console.error(err);
+        setError("Failed to add post.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [canSubmit, title, content, image, user]
   );
 
   const signOutUser = useCallback(() => signOut(auth), []);
@@ -137,15 +149,21 @@ export default function Home() {
                   className="w-full p-2 border"
                   aria-label="Title"
               />
-              <textarea
-                  value={content}
-                  onChange={(e) => setContent(e.target.value)}
-                  placeholder="Content"
-                  className="w-full p-2 border"
-                  rows={6}
-                  aria-label="Content"
-              />
-              <div className="flex items-center gap-2">
+            <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Content"
+                className="w-full p-2 border"
+                rows={6}
+                aria-label="Content"
+            />
+            <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => setImage(e.target.files?.[0] || null)}
+                className="w-full p-2 border"
+            />
+            <div className="flex items-center gap-2">
                 <button
                     type="submit"
                     disabled={!canSubmit}
@@ -160,11 +178,14 @@ export default function Home() {
 
         <ul className="space-y-4">
           {posts.map((post) => (
-              <li key={post.id} className="border p-2 rounded">
-                <h2 className="font-semibold text-lg">{post.title}</h2>
-                <p className="whitespace-pre-wrap">{post.content}</p>
-                <p className="text-sm text-gray-500">{safeDate(post.created as Timestamp | null)}</p>
-              </li>
+            <li key={post.id} className="border p-2 rounded space-y-2">
+              <h2 className="font-semibold text-lg">{post.title}</h2>
+              {post.imageUrl && (
+                <img src={post.imageUrl} alt="post" className="w-full rounded" />
+              )}
+              <p className="whitespace-pre-wrap">{post.content}</p>
+              <p className="text-sm text-gray-500">{safeDate(post.created as Timestamp | null)}</p>
+            </li>
           ))}
         </ul>
       </main>

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -17,7 +17,7 @@ export default function RegisterPage() {
   };
 
   return (
-    <main className="max-w-sm mx-auto p-4 space-y-4">
+    <main className="max-w-sm mx-auto p-4 space-y-4 bg-white text-black min-h-screen flex flex-col justify-center">
       <h1 className="text-xl font-bold text-center">Register</h1>
       <input
         type="email"

--- a/firebase.ts
+++ b/firebase.ts
@@ -3,6 +3,7 @@ import { initializeApp, getApps, FirebaseApp } from "firebase/app";
 import { getAnalytics, Analytics } from "firebase/analytics";
 import { getFirestore, Firestore } from "firebase/firestore";
 import { getAuth, Auth } from "firebase/auth";
+import { getStorage, FirebaseStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBsd8CmzMA4U_p3B5Bimpyne4gRHmHlGR8",
@@ -25,5 +26,6 @@ if (typeof window !== "undefined") {
 
 const firestore: Firestore = getFirestore(app);
 const auth: Auth = getAuth(app);
+const storage: FirebaseStorage = getStorage(app);
 
-export { app as firebaseApp, analytics as firebaseAnalytics, firestore, auth };
+export { app as firebaseApp, analytics as firebaseAnalytics, firestore, auth, storage };


### PR DESCRIPTION
## Summary
- create `/admin` page for logging in and registration
- allow posts to include an image and display it
- tweak login/register pages styling
- expose Firebase storage for uploads

## Testing
- `npm run build` *(fails: Failed to fetch font `Geist`)*
- `npm run lint` *(interactive prompt appears)*

------
https://chatgpt.com/codex/tasks/task_e_6889b51ba37c83289882443baa0c7060