### PR TITLE
Add Latest News section

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,16 @@
 
 :root {
   --accent-color: #1400FF;
+  --bg-color: #0b0b0c;
+  --card-bg-color: #1b1b1b;
+  --text-color: #ffffff;
+  --muted-color: #b3b3b3;
+  --category-bg: #262626;
 }
 
 body {
-  background: #000000;
-  color: #ffffff;
+  background: var(--bg-color);
+  color: var(--text-color);
   font-family: var(--font-geist-sans, Arial, Helvetica, sans-serif);
 }
 
@@ -22,4 +27,11 @@ h6 {
 a {
   color: var(--accent-color);
   text-decoration: underline;
+}
+
+.line-clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,50 @@
+import LatestNewsSection, { NewsItem } from '../../components/LatestNewsSection';
+
+const demoNews: NewsItem[] = [
+  {
+    id: 1,
+    title: 'Tesla unveils new battery tech for extended range',
+    date: 'May 1, 2024',
+    category: 'Tech',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,1',
+  },
+  {
+    id: 2,
+    title: 'Autopilot update improves highway performance',
+    date: 'May 4, 2024',
+    category: 'Update',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,2',
+  },
+  {
+    id: 3,
+    title: 'Gigafactory reaches new production milestone',
+    date: 'May 6, 2024',
+    category: 'News',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,3',
+  },
+  {
+    id: 4,
+    title: 'Model S receives interior design refresh',
+    date: 'May 8, 2024',
+    category: 'Design',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,4',
+  },
+  {
+    id: 5,
+    title: 'Energy division launches new solar roof tiles',
+    date: 'May 10, 2024',
+    category: 'Energy',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,5',
+  },
+  {
+    id: 6,
+    title: 'Supercharger network expands across Europe',
+    date: 'May 12, 2024',
+    category: 'Infrastructure',
+    imageUrl: 'https://source.unsplash.com/random/800x800?technology,6',
+  },
+];
+
+export default function NewsPage() {
+  return <LatestNewsSection items={demoNews} />;
+}

--- a/components/LatestNewsSection.tsx
+++ b/components/LatestNewsSection.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+export type NewsItem = {
+  id: number;
+  title: string;
+  date: string;
+  category: string;
+  imageUrl: string;
+};
+
+interface LatestNewsSectionProps {
+  items: NewsItem[];
+}
+
+export default function LatestNewsSection({ items }: LatestNewsSectionProps) {
+  return (
+    <section className="py-8" style={{ backgroundColor: 'var(--bg-color)' }}>
+      <div className="max-w-6xl mx-auto px-4">
+        <header className="flex justify-between items-center mb-8">
+          <h2 className="text-2xl font-semibold">Latest news</h2>
+          <a href="#" className="text-sm">View all</a>
+        </header>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+          {items.map((item) => (
+            <article
+              key={item.id}
+              className="bg-[var(--card-bg-color)] rounded shadow-lg overflow-hidden transform transition-transform hover:-translate-y-1 hover:shadow-xl"
+            >
+              <div className="aspect-square overflow-hidden">
+                <img
+                  src={item.imageUrl}
+                  alt="thumbnail"
+                  className="w-full h-full object-cover brightness-90 transition hover:brightness-110"
+                  style={{ filter: 'drop-shadow(0 0 8px rgba(255,255,255,0.2))' }}
+                />
+              </div>
+              <div className="p-4 space-y-2">
+                <h3 className="text-lg font-medium leading-tight line-clamp-2">
+                  {item.title}
+                </h3>
+                <div className="flex items-center gap-2 text-sm text-[var(--muted-color)]">
+                  <span className="px-2 py-1 bg-[var(--category-bg)] rounded-full text-xs font-semibold text-[var(--text-color)]">
+                    {item.category}
+                  </span>
+                  <span>{item.date}</span>
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- update global styles with color tokens and utility for line clamping
- implement `LatestNewsSection` component with 6 dummy cards
- add `/news` route displaying the new component

## Testing
- `npm run lint` *(fails interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6889ef1bf46483288a0aa84f5b72d6d0