### PR TITLE
Display latest Firebase posts on home/news pages

### DIFF
--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,50 +1,60 @@
-import LatestNewsSection, { NewsItem } from '../../components/LatestNewsSection';
+"use client";
 
-const demoNews: NewsItem[] = [
-  {
-    id: 1,
-    title: 'Tesla unveils new battery tech for extended range',
-    date: 'May 1, 2024',
-    category: 'Tech',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,1',
-  },
-  {
-    id: 2,
-    title: 'Autopilot update improves highway performance',
-    date: 'May 4, 2024',
-    category: 'Update',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,2',
-  },
-  {
-    id: 3,
-    title: 'Gigafactory reaches new production milestone',
-    date: 'May 6, 2024',
-    category: 'News',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,3',
-  },
-  {
-    id: 4,
-    title: 'Model S receives interior design refresh',
-    date: 'May 8, 2024',
-    category: 'Design',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,4',
-  },
-  {
-    id: 5,
-    title: 'Energy division launches new solar roof tiles',
-    date: 'May 10, 2024',
-    category: 'Energy',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,5',
-  },
-  {
-    id: 6,
-    title: 'Supercharger network expands across Europe',
-    date: 'May 12, 2024',
-    category: 'Infrastructure',
-    imageUrl: 'https://source.unsplash.com/random/800x800?technology,6',
-  },
-];
+import { useEffect, useState, useMemo } from "react";
+import { firestore } from "@/firebase";
+import {
+  collection,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp,
+  type FirestoreDataConverter,
+  type Timestamp,
+  type QueryDocumentSnapshot,
+} from "firebase/firestore";
+import LatestNewsSection, { NewsItem } from "@/components/LatestNewsSection";
+
+type ServerTimestamp = ReturnType<typeof serverTimestamp>;
+export type PostDoc = {
+  title: string;
+  content: string;
+  imageUrl?: string | null;
+  created: Timestamp | ServerTimestamp;
+  uid: string;
+};
+export type Post = PostDoc & { id: string };
+
+const postConverter: FirestoreDataConverter<PostDoc> = {
+  toFirestore: (post: PostDoc) => post,
+  fromFirestore: (snap: QueryDocumentSnapshot): PostDoc => snap.data() as PostDoc,
+};
+
+const safeDate = (ts: Timestamp | ServerTimestamp | null | undefined) =>
+  ts && ts instanceof Timestamp ? ts.toDate().toLocaleDateString() : "…";
 
 export default function NewsPage() {
-  return <LatestNewsSection items={demoNews} />;
+  const [posts, setPosts] = useState<Post[]>([]);
+
+  useEffect(() => {
+    const postsCol = collection(firestore, "posts").withConverter(postConverter);
+    const postsQuery = query(postsCol, orderBy("created", "desc"));
+    return onSnapshot(postsQuery, (snap) =>
+      setPosts(snap.docs.map((d) => ({ id: d.id, ...(d.data() as PostDoc) })))
+    );
+  }, []);
+
+  const newsItems = useMemo<NewsItem[]>(
+    () =>
+      posts.slice(0, 6).map((p, idx) => ({
+        id: idx + 1,
+        title: p.title,
+        date: safeDate(p.created as Timestamp | null),
+        category: "Post",
+        imageUrl:
+          p.imageUrl || `https://source.unsplash.com/random/800x800?news,${idx}`,
+      })),
+    [posts]
+  );
+
+  return <LatestNewsSection items={newsItems} />;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,7 @@ import {
 } from "firebase/storage";
 import { onAuthStateChanged, signOut, User } from "firebase/auth";
 import type { FirebaseError } from "firebase/app";
+import LatestNewsSection, { NewsItem } from "@/components/LatestNewsSection";
 
 type ServerTimestamp = ReturnType<typeof serverTimestamp>;
 type PostDoc = { title: string; content: string; imageUrl?: string | null; created: Timestamp | ServerTimestamp; uid: string; };
@@ -67,6 +68,16 @@ export default function Home() {
     const [progress, setProgress] = useState<number>(0);
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
+
+    const newsItems = useMemo<NewsItem[]>(() =>
+        posts.slice(0, 6).map((p, idx) => ({
+            id: idx + 1,
+            title: p.title,
+            date: safeDate(p.created as Timestamp | null),
+            category: "Post",
+            imageUrl: p.imageUrl || `https://source.unsplash.com/random/800x800?news,${idx}`,
+        })),
+        [posts]);
 
     useEffect(() => onAuthStateChanged(auth, setUser), []);
 
@@ -172,6 +183,10 @@ export default function Home() {
                         {error && <span className="text-sm text-red-600">{error}</span>}
                     </div>
                 </form>
+            )}
+
+            {newsItems.length > 0 && (
+                <LatestNewsSection items={newsItems} />
             )}
 
             <ul className="divide-y space-y-8">


### PR DESCRIPTION
## Summary
- add `LatestNewsSection` to homepage showing the most recent posts
- convert `/news` page to pull posts from Firebase

## Testing
- `npm run lint` *(fails: asks to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_6889f11907208328be4b9f6178b0beb8