### PR TITLE
feat: add site footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Footer from "@/components/Footer";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,6 +29,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Footer />
       </body>
     </html>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer className="border-t mt-12 py-6 text-center text-sm text-gray-500">
+      <p>© {new Date().getFullYear()} My Next Project. All rights reserved.</p>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable footer component
- include footer across site layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive setup)


------
https://chatgpt.com/codex/tasks/task_e_68945965e980832884b07adb307157d2