### PR TITLE
feat: add firebase storage image uploads

### DIFF
--- a/firebase.ts
+++ b/firebase.ts
@@ -3,6 +3,7 @@ import { initializeApp, getApps, FirebaseApp } from "firebase/app";
 import { getAnalytics, Analytics } from "firebase/analytics";
 import { getFirestore, Firestore } from "firebase/firestore";
 import { getAuth, Auth } from "firebase/auth";
+import { getStorage, FirebaseStorage } from "firebase/storage";
 
 const firebaseConfig = {
   apiKey: "AIzaSyBsd8CmzMA4U_p3B5Bimpyne4gRHmHlGR8",
@@ -25,5 +26,6 @@ if (typeof window !== "undefined") {
 
 const firestore: Firestore = getFirestore(app);
 const auth: Auth = getAuth(app);
+const storage: FirebaseStorage = getStorage(app);
 
-export { app as firebaseApp, analytics as firebaseAnalytics, firestore, auth };
+export { app as firebaseApp, analytics as firebaseAnalytics, firestore, auth, storage };


### PR DESCRIPTION
## Summary
- initialize Firebase storage and export for use across the app
- allow posts to include optional image uploads stored in Firebase Storage

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Failed to fetch font `Geist`)


------
https://chatgpt.com/codex/tasks/task_e_6894604b3ca08328b4fd3bd368305697